### PR TITLE
Remove API key authentication via query string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/host-uk/core"
+            "url": "https://github.com/host-uk/core-php"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,12 @@
     "description": "MCP (Model Context Protocol) tools module for Core PHP framework",
     "keywords": ["laravel", "mcp", "ai", "tools", "claude"],
     "license": "EUPL-1.2",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/host-uk/core"
+        }
+    ],
     "require": {
         "php": "^8.2",
         "host-uk/core": "@dev"

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,17 @@
         "php": "^8.2",
         "host-uk/core": "@dev"
     },
+    "require-dev": {
+        "larastan/larastan": "^3.9",
+        "laravel/pint": "^1.18",
+        "nunomaduro/collision": "^8.6",
+        "pestphp/pest": "^3.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^11.5",
+        "psalm/plugin-laravel": "^3.0",
+        "vimeo/psalm": "^6.14"
+    },
     "autoload": {
         "psr-4": {
             "Core\\Mcp\\": "src/Mcp/",

--- a/src/Mcp/Middleware/McpAuthenticate.php
+++ b/src/Mcp/Middleware/McpAuthenticate.php
@@ -58,13 +58,12 @@ class McpAuthenticate
     }
 
     /**
-     * Authenticate using API key from header or query.
+     * Authenticate using API key from header.
      */
     protected function authenticateByApiKey(Request $request): ?Workspace
     {
         $apiKey = $request->header('X-API-Key')
-            ?? $request->header('Authorization')
-            ?? $request->query('api_key');
+            ?? $request->header('Authorization');
 
         if (! $apiKey) {
             return null;


### PR DESCRIPTION
The McpAuthenticate middleware was accepting API keys from query parameters, which is a security anti-pattern. This change removes that option and ensures API keys are only accepted via headers. The documentation for the method was also updated to reflect this change.

Fixes #8

---
*PR created automatically by Jules for task [8198341539587582470](https://jules.google.com/task/8198341539587582470) started by @Snider*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * API key authentication is now restricted to header-based methods only. The X-API-Key and Authorization headers are the only accepted authentication sources. Query parameter authentication has been removed.

* **Chores**
  * Development tooling and dependencies have been enhanced to support improved testing and code quality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->